### PR TITLE
docs(notes): Durable Object stub age, synthetic ledger identities

### DIFF
--- a/notes/cloudflare/durable-object-stubs-age-across-a-long-cron-tick.md
+++ b/notes/cloudflare/durable-object-stubs-age-across-a-long-cron-tick.md
@@ -1,0 +1,30 @@
+---
+title: "Durable Object stubs age across a long cron tick"
+date: 2026-09-04
+captured: 2026-09-04T09:40:00Z
+tags: [cloudflare, durable-objects, workers, debugging]
+source: "Claude Code session"
+aliases: [durable object reset because its code was updated]
+status: refined
+---
+
+## Question
+
+A Cloudflare Workers cron tick calls a Durable Object several times over a few minutes. The last call fails on every tick with `Durable Object reset because its code was updated`, yet nothing was deployed. Why, and what is the fix?
+
+## Cause
+
+A Durable Object stub is a client bound to one live instance of the object. When that instance is reset (a deploy, an eviction, a runtime move), every later call through the old stub answers with that message. The error text names one common trigger, a code update, but the same failure follows any reset.
+
+The trap is stub age. A tick that obtains one stub at the start and reuses it minutes later, after a paced pass with retries, hands the runtime a stale client. The deploy that reset the object may have happened long before; the stub only notices on its next call.
+
+## Fix
+
+- Take a fresh stub per call: `env.NS.get(env.NS.idFromName(key))` right before each RPC, never once per tick.
+- Bound each RPC to seconds, not minutes. Split a long pass into chunks (a handful of addresses per hop) and loop in the Worker with a fresh stub per chunk.
+- Keep retry ladders inside the RPC client, so a single hop never spans the window where a reset can land.
+- Log one summary line per pass and one line per refused item with a safe reason; a silent pass made this look like a rate limit for hours.
+
+## Key Takeaway
+
+A stub is a connection, not a handle. Reacquire it per call and keep every hop short.

--- a/notes/crypto/synthetic-ledger-identities-and-receipt-lookups.md
+++ b/notes/crypto/synthetic-ledger-identities-and-receipt-lookups.md
@@ -1,0 +1,32 @@
+---
+title: "Synthetic ledger identities must never reach a receipt lookup"
+date: 2026-09-04
+captured: 2026-09-04T09:40:00Z
+tags: [ledger, evm, deposits, debugging]
+source: "Claude Code session"
+aliases: [opening balance credit identity, eth_getTransactionReceipt invalid params]
+status: refined
+---
+
+## Question
+
+A custodial deposit ledger keys every credit by its on-chain transaction hash. An opening-balance pass then credits historical holdings with a synthetic identity such as `opening:<chain>:<address>:<token>`. From that moment the chain's detection pass reports zero scans and one error per tick. What happened?
+
+## Root cause
+
+The reorg checker walks every credited row and asks the RPC for the transaction receipt behind its identity. A synthetic identity is not a hash, so `eth_getTransactionReceipt` answers `-32602 invalid params`. The per-chain catch treats that as a chain failure, the whole pass is discarded after the credits are written, and the chain's summary line disappears. Credits and the scan cursor still advance, which is why nothing looked stuck.
+
+Two compounding faults hid it for a day:
+
+- The chain error log printed only the error's name, a bare `Error`, so a malformed parameter looked identical to a throttle.
+- The opening pass had no test that fed its identities through the reorg path.
+
+## Fix
+
+- Guard at the boundary that consumes identities as hashes: skip or branch on any identity that is not `0x`-prefixed before calling the receipt RPC.
+- Log a redacted reason with the HTTP status and the JSON-RPC error code, never the endpoint (it carries the key), so `-32602` and `429` read differently.
+- Give every identity producer a test that runs its output through every consumer that assumes a hash.
+
+## Key Takeaway
+
+Any field that is usually a transaction hash needs a type at the boundary, not a naming convention. When a new producer mints a different shape, every reader that assumed the old shape breaks quietly.


### PR DESCRIPTION
Two privacy-stripped notes from a Cloudflare Workers custodial-ledger incident day: stub age across a long cron tick, and synthetic credit identities reaching a receipt lookup.