### PR TITLE
docs(notes): six notes from the ledger flush

### DIFF
--- a/notes/devtools/git-reset-keep-drops-a-duplicate-commit-when-hard-is-forbidden.md
+++ b/notes/devtools/git-reset-keep-drops-a-duplicate-commit-when-hard-is-forbidden.md
@@ -1,0 +1,35 @@
+---
+title: "git reset --keep drops a duplicate commit when --hard is forbidden"
+date: 2026-09-05
+captured: 2026-09-05T09:40:00Z
+tags: [git, devtools, workflow]
+source: "Claude Code session"
+aliases: [git reset --keep, duplicate commit after merge, reset hard blocked by hook, local branch ahead with identical commit]
+status: refined
+---
+
+**When a local branch carries a commit whose content is already on the remote (the same diff applied twice, for example once from each of two worktrees), `git reset --keep origin/main` discards the redundant commit without touching uncommitted work, and it passes a safety hook that blocks `git reset --hard`.**
+
+## The situation
+
+After a merge, `git log origin/main..HEAD` still showed one local commit. `git show <local>` and `git show <origin>` were byte-identical: same message, same diff. Pushing would have created a pointless merge of a duplicate; `git reset --hard origin/main` was blocked by a repo hook that refuses `--hard` whenever untracked or modified files exist.
+
+## Why `--keep` is the right verb
+
+| Mode | Index | Working tree | Local modifications |
+|---|---|---|---|
+| `--soft` | untouched | untouched | kept, still staged |
+| `--mixed` (default) | reset | untouched | kept, unstaged |
+| `--keep` | reset | reset for files the commits changed | kept; aborts if a modified file would be overwritten |
+| `--hard` | reset | reset | destroyed |
+
+`--keep` moves the branch pointer to the target, updates only the paths that differ between the commits, and refuses to proceed if any of those paths has local changes. That is the guarantee a "no `--hard`" hook exists to enforce, so the hook can allow it.
+
+```bash
+git fetch origin
+git diff origin/main HEAD --stat        # expect: nothing, the content is already upstream
+git reset --keep origin/main
+git log --oneline -1                     # now equal to origin/main
+```
+
+If `--keep` aborts with "Entry ... not uptodate", a modified file overlaps the commits being dropped; stash or commit it first rather than reaching for `--hard`.

--- a/notes/ios/apple-wallet-passes-need-a-pass-type-id-certificate.md
+++ b/notes/ios/apple-wallet-passes-need-a-pass-type-id-certificate.md
@@ -1,0 +1,31 @@
+---
+title: "Apple Wallet passes need a Pass Type ID certificate and do not exist on macOS"
+date: 2026-09-05
+captured: 2026-09-05T09:40:00Z
+tags: [ios, apple-wallet, pkpass]
+source: "Claude Code session"
+aliases: [pkpass will not add, wallet pass signing, pass type id certificate, no wallet app on mac, self-issued wallet pass]
+status: refined
+---
+
+**A `.pkpass` installs on an iPhone only when it is signed by an Apple Pass Type ID certificate issued to a paid developer account, and macOS has no Wallet app at all, so a pass can be neither added nor tested on a Mac.**
+
+An airline or venue pass "just works" because the issuer signed it; the signature (a PKCS#7 `signature` file inside the zip, over `manifest.json`) is what Wallet validates, and an unsigned or self-signed bundle is rejected with no useful error. The same applies to passes opened from Mail, Safari, AirDrop or Files.
+
+## What self-issuing costs
+
+| Requirement | Detail |
+|---|---|
+| Apple Developer Program | paid membership |
+| Pass Type ID | created in the developer portal, one per pass kind |
+| Pass Type ID certificate | issued against a CSR, used to sign every pass |
+| WWDR intermediate | included in the signature chain |
+| Signing step | `openssl smime -sign` or PassKit tooling over `manifest.json` |
+
+Even then a self-issued pass is a reference card: it shows text, a barcode image and colors, but nothing scans it into any system unless a reader on the other side expects that barcode. A "membership pass" for a household or a small team is a picture in a wallet, not a credential.
+
+## Alternatives that skip the certificate
+
+- A plain image or PDF in Files or Photos, for something only a human reads.
+- A URL or QR code that opens a web page, for something a phone scans.
+- A third-party pass service (they sign with their certificate), when the pass must live in Wallet and the volume justifies the fee.

--- a/notes/ios/iphone-storage-last-used-is-a-one-month-window.md
+++ b/notes/ios/iphone-storage-last-used-is-a-one-month-window.md
@@ -1,0 +1,34 @@
+---
+title: "iPhone Storage \"Last Used\" is a one-month window and the only usage signal iOS exposes"
+date: 2026-09-05
+captured: 2026-09-05T09:40:00Z
+tags: [ios, storage, ocr]
+source: "Claude Code session"
+aliases: [iphone storage last used, ios app last opened date, installation_proxy no usage data, which iphone apps are unused]
+status: refined
+---
+
+**iOS exposes app usage in exactly one place, Settings > General > iPhone Storage, and only as a "Last Used" subtitle for apps opened within roughly the last month. Nothing in the device APIs carries it.**
+
+Verified on iOS 26 with a full `ideviceinstaller list --xml` dump: the installation-proxy metadata has bundle ids, versions, sizes and dates for install and update, and no field for last launch. The Storage screen is rendered from usage data the phone keeps but does not export.
+
+## Reading the absence
+
+| Storage row shows | Meaning |
+|---|---|
+| `Last Used: <date>` | opened within about the last month (oldest value observed: 26 days back) |
+| no subtitle | not opened in over a month |
+| `Never Used` | not seen on iOS 26 at all in a list of 260 apps |
+
+So the cull signal is the missing subtitle, not a date: every row without one is a candidate.
+
+## Getting it at scale
+
+The screen is a scrolling list with no export, so capture it as video and read it back:
+
+1. Screen-record a slow scroll through iPhone Storage (260 apps took a few minutes).
+2. Extract frames: `ffmpeg -i rec.mp4 -vf fps=2 frames/%04d.png`.
+3. OCR the frames (Apple's Vision framework works from a Swift script, about one second per frame).
+4. Join the OCR'd app names against `ideviceinstaller list --user` to get bundle ids, and treat "name present, no Last Used line" as unused.
+
+The join is fuzzy (OCR mangles some names) but the false-negative direction is safe: an app you cannot match stays installed.

--- a/notes/ios/uninstall-ios-apps-in-bulk-from-a-mac-without-jailbreak.md
+++ b/notes/ios/uninstall-ios-apps-in-bulk-from-a-mac-without-jailbreak.md
@@ -1,0 +1,43 @@
+---
+title: "Uninstall iOS apps in bulk from a Mac without jailbreak"
+date: 2026-09-05
+captured: 2026-09-05T09:40:00Z
+tags: [ios, macos, cli, libimobiledevice]
+source: "Claude Code session"
+aliases: [ideviceinstaller uninstall, remove iphone apps from terminal, libimobiledevice app list, iphone app cull]
+status: refined
+---
+
+**`ideviceinstaller` (libimobiledevice) uninstalls apps over the cable through the same installation service iTunes once used: no jailbreak, no developer account, one "Trust This Computer" tap.**
+
+## Setup
+
+```bash
+brew install ideviceinstaller      # pulls libimobiledevice
+# plug the phone in, unlock it, tap Trust This Computer
+idevicepair pair                   # once
+```
+
+## List and uninstall
+
+```bash
+ideviceinstaller list --user > apps.txt       # bundle id, version, name; the old -l flag is gone
+ideviceinstaller uninstall com.example.app    # one app
+```
+
+For a cull, keep a file of bundle ids (one per line) and loop:
+
+```bash
+while IFS= read -r bundle; do
+  [ -n "$bundle" ] || continue
+  ideviceinstaller uninstall "$bundle" && echo "removed $bundle"
+done < to-remove.txt
+```
+
+One pass removed 104 apps (262 down to 158) with zero failures, roughly a second each. The phone shows each icon vanish as it goes.
+
+## Limits worth knowing
+
+- `--user` lists user-installed apps only; system apps are not removable this way.
+- The metadata it returns (`--xml`) has no usage or last-opened dates, so "which apps are unused" has to come from somewhere else (see the iPhone Storage "Last Used" note).
+- The device must stay unlocked for the first command after pairing; later commands work with the screen off.

--- a/notes/macos/apple-vision-ocr-as-an-interpreted-swift-cli.md
+++ b/notes/macos/apple-vision-ocr-as-an-interpreted-swift-cli.md
@@ -1,0 +1,42 @@
+---
+title: "Apple Vision OCR as an interpreted Swift CLI, no build step"
+date: 2026-09-05
+captured: 2026-09-05T09:40:00Z
+tags: [macos, swift, ocr, vision]
+source: "Claude Code session"
+aliases: [swift script ocr, VNRecognizeTextRequest command line, run swift file without compiling, vietnamese ocr macos]
+status: refined
+---
+
+**A `.swift` file that imports Vision runs directly with `swift file.swift args...`, so macOS ships an accurate multilingual OCR command line with nothing to install: no Xcode project, no compile, no Homebrew.**
+
+```swift
+import Vision
+import AppKit
+
+let args = Array(CommandLine.arguments.dropFirst())
+for path in args {
+    guard let img = NSImage(contentsOfFile: path),
+          let cg = img.cgImage(forProposedRect: nil, context: nil, hints: nil) else { continue }
+    let request = VNRecognizeTextRequest { req, _ in
+        for obs in req.results as? [VNRecognizedTextObservation] ?? [] {
+            if let top = obs.topCandidates(1).first { print("\(path)\t\(top.string)") }
+        }
+    }
+    request.recognitionLevel = .accurate
+    request.recognitionLanguages = ["en-US", "vi-VN"]
+    try? VNImageRequestHandler(cgImage: cg, options: [:]).perform([request])
+}
+```
+
+```bash
+swift ocr-frames.swift frames/*.png > ocr.txt
+```
+
+About one second per 2x-scaled phone screenshot at `.accurate`; `.fast` is several times quicker and good enough for large UI text. `recognitionLanguages` takes BCP-47 tags and the Vietnamese model handles diacritics correctly, which Tesseract's default traineddata does not.
+
+## Why interpreted
+
+The script is the tool: edit, rerun, no toolchain state. It fits pipelines such as `ffmpeg -vf fps=2` frame extraction followed by a text parser, where the OCR step is one line in a shell script. The first run is slow (the Swift interpreter type-checks the file) and the frameworks load per process, so batch many images per invocation instead of calling it once per file.
+
+Caveats: `swift file.swift` needs the Xcode command line tools; Vision is macOS 10.15+ and its language list is per OS version (`VNRecognizeTextRequest.supportedRecognitionLanguages()` prints it).

--- a/notes/security/shell-values-in-python-c-source-are-an-injection.md
+++ b/notes/security/shell-values-in-python-c-source-are-an-injection.md
@@ -1,0 +1,38 @@
+---
+title: "Shell values spliced into python3 -c source are an injection"
+date: 2026-09-05
+captured: 2026-09-05T09:40:00Z
+tags: [bash, python, security, injection]
+source: "Claude Code session"
+aliases: [python3 -c interpolation, bash variable in inline python, source config file executes it, KEY=value config parsing]
+status: refined
+---
+
+**A bash script that builds Python source by string interpolation (`python3 -c "... glob.glob('$src_dir/*.md') ..."`) hands every shell value to the Python parser as code.** A path containing a single quote, a backslash or a newline breaks the string literal at best and rewrites the program at worst. The bug is silent for ordinary paths and appears the first time a directory name carries punctuation.
+
+## The safe form
+
+Pass values through the environment and read them inside Python; the shell never touches the Python source:
+
+```bash
+SRC_DIR="$src_dir" VI_DIR="$vi_dir" python3 -c '
+import glob, os
+files = glob.glob(os.path.join(os.environ["SRC_DIR"], "*.md"))
+'
+```
+
+Single-quote the Python so bash leaves it alone, and let `os.environ` do the crossing. The same applies to `perl -e`, `node -e`, `ruby -e` and to `jq` (use `--arg name "$value"`, never `".key == \"$value\""`).
+
+## The sibling bug: sourcing a config file
+
+`source book.conf` to read `KEY=value` settings executes the file as bash, so a value like `title="$(rm -rf ~)"` runs. Parse it as text instead:
+
+```bash
+title=$(grep -E '^title=' book.conf | cut -d= -f2- | tr -d '"')
+```
+
+or read it with `while IFS='=' read -r key value`. A config file is data; anything that evaluates it has turned it into code.
+
+## How to spot it
+
+Any `-c "..."` or `-e "..."` in double quotes with a `$` inside, and any `source` / `.` of a file a user or a job can edit. Both are the same mistake: data reaching an interpreter through the code channel.


### PR DESCRIPTION
Six learned-ledger rows flushed to til (ops-toolkit closeout, 2026-09-05): shell values in python3 -c source, git reset --keep for a duplicate commit, ideviceinstaller bulk uninstall, iPhone Storage Last Used window, Vision OCR as an interpreted Swift CLI, Apple Wallet pass signing. Pushed via git because the GitHub MCP worker's PAT returns 401 today. Not yet compiled into index.md/log.md.