### PR TITLE
docs(notes): travel hacking from Vietnam, the 2026 landscape

### DIFF
--- a/notes/travel/travel-hacking-from-vietnam-2026.md
+++ b/notes/travel/travel-hacking-from-vietnam-2026.md
@@ -1,0 +1,69 @@
+---
+title: "Travel hacking from Vietnam, the 2026 landscape"
+date: 2026-09-06
+captured: 2026-09-06T02:40
+tags: [travel, vietnam, loyalty, airlines]
+source: "Claude Code session, ops-toolkit research"
+aliases: [vietnam-frequent-flyer-2026]
+status: refined
+type: article
+---
+
+**For a Vietnam-based traveler flying domestic and regional Southeast Asia in economy, airline status is the wrong lever in 2026. Vietnam Airlines gives lounge and priority security only at Platinum (50 segments a year), a free government biometric lane does the fast-track job, and a card-network lounge membership costs less than two door passes.** The rest of this note is the landscape that conclusion came out of, with the numbers as of September 2026.
+
+## Loyalty: what the tiers actually give
+
+| Lotusmiles tier | Qualifying (12 months) | SkyTeam | Lounge | Priority security | Priority check-in |
+|---|---|---|---|---|---|
+| Titanium | 15,000 miles or 20 segments | Elite | no | no | yes |
+| Gold | 30,000 or 30 | Elite | no | no | yes |
+| Platinum | 50,000 or 50 | Elite Plus | yes, plus one guest | where available | yes |
+
+Two traps that read as hacks online. The 2026 paid status match (USD 129 to 359) needs existing airline elite status to reach Platinum; a hotel-status match tops out at Gold, which buys nothing at the airport. And miles expire on a fixed three-year clock with no activity reset; the only extension window is the last six months, at USD 5 per 500 miles.
+
+Where Lotusmiles does pay: Titanium arrives free after twenty domestic segments, the Premium Economy Flex fare gets a free space-available Business upgrade at domestic check-in since August 2026, and Lite fares are excluded from every upgrade path, so book Classic or Flex when an upgrade is in play.
+
+Redemption is better through a partner. Flying Blue prices Vietnam Airlines' own metal at 6,000 miles economy and 15,000 business intra-Asia with no fuel surcharge; Lotusmiles charges 13,000 to Southeast Asia plus surcharge. Cathay Asia Miles is the second tool for anything via Hong Kong. Lotusmiles has no online partner-award search, so the workflow is search on the partner, then phone.
+
+Vietjet's SkyJoy is a spend-back scheme with no other airline partners; join for free, never chase it. Bamboo Airways suspended scheduled sales in August 2026 and Jetstar Asia closed in July 2025; neither program is worth holding miles in.
+
+## Airport friction
+
+The manned ID check before screening is the queue. Vietnamese citizens with a Level 2 VNeID account walk a biometric lane at Tan Son Nhat T3, Da Nang T1 and Noi Bai T1, face-matched against the booking, no ID and no boarding pass shown. Domestic identity checks went biometric by default in December 2025. This is free and does what a paid fast track sells; no operator sells a domestic fast track at the new T3 anyway.
+
+Tan Son Nhat's terminals are no longer one building. T3 took domestic Vietnam Airlines and Vietjet in 2025, T2 stays international, T1 keeps three small routes, and the three sit about 850 metres apart with a shuttle every twenty minutes. A domestic-to-international connection needs a real buffer.
+
+Lounges honouring the card networks on the domestic side are few: SH Premium at Da Nang T1 (Priority Pass and DragonPass), SH Premium and The SENS at Tan Son Nhat T3 (Priority Pass). The airline and bank lounges (Lotus, Vietcombank Priority) are closed to card networks. Door passes run 360,000 to 500,000 VND at Da Nang and about USD 55 at T3, so any card with four visits a year already wins. Vietnamese Visa Signature and Infinite cards carry DragonPass or Priority Pass with one visit a quarter as the common shape, and issuers rewrite the terms several times a year, so the bank's page beats any blog.
+
+## Entry rules for a Vietnamese passport
+
+| Destination | Entry | E-gate |
+|---|---|---|
+| Singapore | visa-free | yes, all nationalities after a one-time enrolment |
+| Malaysia | visa-free | ASEAN lane; arrival card mandatory |
+| Thailand, Indonesia, Philippines | visa-free | unverified |
+| Taiwan | eVisa | no |
+| Hong Kong | visa-free | no |
+| Japan, Korea | visa required | no |
+
+The APEC Business Travel Card changes that table: Japan, Korea, Taiwan, Hong Kong and China become visa-free with a dedicated APEC lane, three years validity, for company directors and executives (Decision 28/2026/QD-TTg, filed with the Immigration Department, about three months). It is the single largest friction cut available to a Vietnamese passport and it is barely discussed in travel-hacking circles.
+
+## Fares
+
+Vietjet runs a daily 0 VND base-fare window from 12:00 to 14:00 and three-day double-date sales (7/7, 9/9) with a year-long travel window; taxes and fees of 300,000 to 800,000 VND survive the zero. Domestic fares sit under a government ceiling by distance band (1.6M to 4M VND one way) with no floor. Booking Tuesday is folklore now; departing Tuesday to Thursday still runs 13 to 20 percent cheaper on Asian routes. Pay in VND and refuse dynamic currency conversion, whose markup runs 2.6 to 18 percent against a card's own 1 to 3 percent.
+
+## Building a fare watcher in 2026
+
+Every hobbyist flight API is gone or gated: Amadeus Self-Service was decommissioned in July 2026, Kiwi Tequila went invitation-only in 2024, Skyscanner is partner-only. What remains is Google Flights, which lists Vietjet, Vietnam Airlines, Vietravel and Sun PhuQuoc domestic fares in VND. The `fast-flights` Python package builds the protobuf query and parses the page. Three findings from running it daily:
+
+- Adding a child to the party makes Google drop Vietnam Airlines from the result set; watch family legs as adults.
+- A business-class query for a party with no business inventory returns a page the parser dies on; keep it best effort.
+- The package's Rust HTTP client runs its own resolver and appends the host's DNS search domain (a Tailscale one, in this case), failing on `www.google.com.<search-domain>`; fetch the page with the standard library and hand only the HTML to the parser.
+
+Travelpayouts' data API is the free supplementary source for cheapest-day calendars; SerpApi is the zero-maintenance paid alternative at USD 25 per thousand searches.
+
+## Hotels and ground
+
+Accor has the densest Vietnam footprint and the easiest small-company entry (twenty room-nights a year, no contract). IHG ran a Visa Infinite fast track to Platinum at six nights in ninety days through December 2026, also reachable through Grab's VIP tier. Booking.com Genius level 3 is fifteen bookings in two years and stays for life. Past about ten nights a serviced apartment beats any loyalty math.
+
+Regional transit payment has three gotchas: Suica in Apple Wallet refuses top-ups from foreign Visa cards (Mastercard and Amex work), Octopus in Apple Wallet needs a Hong Kong card to top up (use the tourist app instead), and Taipei's metro and airport MRT took direct contactless card taps from July 2026. Wise and Revolut do not open accounts for Vietnam residents; a card opened under another residency works fine inside Vietnam.


### PR DESCRIPTION
Landscape note distilled from a four-pass research snapshot: Lotusmiles tier reality, VNeID biometric lanes, Tan Son Nhat T3 split, card-network lounges, entry rules and the APEC card, Vietjet fare mechanics, and what is left of hobbyist flight APIs in 2026 with three findings from running a Google Flights watcher. New folder notes/travel. Personal trip plan, cards held, company and family details stripped.